### PR TITLE
Bump to v1.2.0, add entry_points to build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rich-click" %}
-{% set version = "1.1.1" %}
+{% set version = "1.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,14 @@ package:
 
 source:
   url: https://github.com/ewels/rich-click/archive/v{{ version }}.tar.gz
-  sha256: 6204e3ae465abca7cf630649d9c9b7853d4ec404c85eeab03b8af77db91616f3
+  sha256: 74e55790e230ede1d642017810cfde12940a5b831026addb2e82195949ca3359
 
 build:
   number: 0
   noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
+  entry_points:
+    - rich-click=rich_click.cli:main
 
 requirements:
   host:


### PR DESCRIPTION
Hopefully future updates will be automatic from PyPI, but in this release we [add a CLI tool ](https://github.com/ewels/rich-click/pull/13) so need to add to the `build` section as discussed in https://github.com/conda-forge/staged-recipes/pull/18181#issuecomment-1054571546


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
