### PR TITLE
chore: remove upper version limit for rich and add CLI test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2ec411a97d9fbb848906b6f64f535c62217753c015fb9ff950dc4e2cb7de8a72
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -22,7 +22,7 @@ requirements:
     - pip
   run:
     - python >=3.6
-    - rich >=10,<12
+    - rich >=10
     - click >=7,<9
 
 test:
@@ -32,6 +32,7 @@ test:
     - pip
   commands:
     - pip check
+    - rich-click --help
 
 about:
   home: https://github.com/ewels/rich-click


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.


Fix [#44](https://github.com/ewels/rich-click/issues/44) 

I also added another command to tests for the CLI to rich-click.